### PR TITLE
Replace MD5 usage with SHA-512 for FIPS Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Each unique ID has 4 sections and has 24 chars, which are:
 i.e. he5fps6l2504cd1w3ag8ut8e // he5fps6l-2504cd-1w3a-g8ut8e
 
 -	timestamp: 'he5fps6l' // (8) Timestamp in milliseconds - safe until 2059
--	machineId: '2504cd' // (6) First 6 chars from md5 of first external network interface or fallback to hostname
+-	machineId: '2504cd' // (6) First 6 chars from SHA-512 of first external network interface or fallback to hostname
 -	processId: '1w3a' // (4) pid
 -	counter: 'g8ut8e' // (6) High-resolution real time; nanoseconds
 

--- a/lib/puid.js
+++ b/lib/puid.js
@@ -105,7 +105,7 @@ Puid.prototype.getNodeId = function getNodeId(networkInterfaces, fallback) {
         }
     }
 
-    return crypto.createHash('md5')
+    return crypto.createHash('sha512')
         .update(fallback || value || os.hostname(), 'utf8')
         .digest('hex')
         .slice(-this.config.nlen);

--- a/test/test-long-puid.js
+++ b/test/test-long-puid.js
@@ -180,19 +180,19 @@ describe('test long puid', function() {
                 .should.have.length(6);
         });
 
-        it('should be 089776', function() {
+        it('should be eaad43', function() {
             pid.getNodeId(m0)
-                .should.be.eql('089776');
+                .should.be.eql('eaad43');
         });
 
-        it('should be a093d8', function() {
+        it('should be 9d64a8', function() {
             pid.getNodeId(m1)
-                .should.be.eql('a093d8');
+                .should.be.eql('9d64a8');
         });
 
-        it('should be dcfbe5', function() {
+        it('should be 90d936', function() {
             pid.getNodeId(m2)
-                .should.be.eql('dcfbe5');
+                .should.be.eql('90d936');
         });
 
         it('should be a sexhex value', function() {
@@ -202,14 +202,14 @@ describe('test long puid', function() {
 
         it('should use consistent fallback value', function() {
             pid.getNodeId(m3, 'localhost')
-                .should.be.equal('d13e79');
+                .should.be.equal('abe264');
             pid.getNodeId(m3, 'localhost')
                 .should.have.length(6);
         });
 
         it('should use consistent fallback value without external network interfaces', function() {
             pid.getNodeId({}, 'localhost')
-                .should.be.equal('d13e79');
+                .should.be.equal('abe264');
             pid.getNodeId({}, 'localhost')
                 .should.have.length(6);
         });


### PR DESCRIPTION
This replaces the insecure MD5 hashing algorithm with a FIPS compliant hashing algorithm. This enables `puid` to be used in a NodeJS runtime with the [`--force-fips`](https://nodejs.org/api/cli.html#cli_force_fips) flag turned on.